### PR TITLE
Add py3-ready check-apt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org
 
 
 By default this looks for dependencies on the debian package named **python**.
-Use **--target** to change which package to look for recursive dependency.
+Use **--target** to change this name.
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ The exit code is 1 if it does depend on python.
 Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org/doc/info/lang.html>`_ format.
 
 ::
+
     py3-ready check-apt --dot libboost-all-dev
 
 
@@ -28,6 +29,7 @@ By default this looks for dependencies on the debian package named **python**.
 Use **--target** to change which package to look for recursive dependency.
 
 ::
+
     py3-ready check-apt --target python3 libboost-all-dev
 
 Use **--quiet** to suppress warnings and human readable output.

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The exit code is 1 if it does depend on python.
 
     py3-ready check-apt libboost-python-dev
 
-Passing **--dot** outputs the dependency graph in `DOT https://www.graphviz.org/doc/info/lang.html`_ format.
+Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org/doc/info/lang.html>`_ format.
 
 ::
     py3-ready check-apt --dot libboost-all-dev

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,6 @@ It exits with code 1 if the package does depend on python 2, otherwise the exit 
     py3-ready check-apt libboost-python-dev
 
 Output
-%%%%%%
 
 ::
 
@@ -33,7 +32,6 @@ Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org
     py3-ready check-apt --dot libboost-all-dev
 
 Output
-%%%%%%
 
 ::
 
@@ -76,7 +74,6 @@ Use **--quiet** to suppress warnings and human readable output.
     py3-ready check-apt --dot --quiet libboost-python-dev
 
 Output
-%%%%%%
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,49 @@ It exits with code 1 if the package does depend on python 2, otherwise the exit 
 
     py3-ready check-apt libboost-python-dev
 
+Output
+%%%%%%
+
+::
+
+    $ py3-ready check-apt libboost-python-dev
+    libboost-python-dev depends on python
+
+
 Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org/doc/info/lang.html>`_ format.
 
 ::
 
     py3-ready check-apt --dot libboost-all-dev
+
+Output
+%%%%%%
+
+::
+
+    $ py3-ready check-apt --dot libboost-all-dev
+    'kldutils' not in apt cache. Used by 'dkms' as 'Depends: kmod | kldutils'
+    'xorg-video-abi-11' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-12' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-13' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-14' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-15' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-18' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-19' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    'xorg-video-abi-20' not in apt cache. Used by 'nvidia-340' as 'Depends: xorg-video-abi-11 | xorg-video-abi-12 | xorg-video-abi-13 | xorg-video-abi-14 | xorg-video-abi-15 | xorg-video-abi-18 | xorg-video-abi-19 | xorg-video-abi-20 | xorg-video-abi-23 | xorg-video-abi-24'
+    digraph G {
+      "libboost-mpi-python1.65.1" -> "python"[color=blue];  // Depends
+      "libboost-python1.65-dev" -> "python-dev"[color=blue];  // Depends
+      "python-dev" -> "python"[color=blue];  // Depends
+      "python:any" -> "python"[color=green];  // virtual
+      "libboost-mpi-python-dev" -> "libboost-mpi-python1.65-dev"[color=blue];  // Depends
+      "libboost-mpi-python1.65.1" -> "python:any"[color=blue];  // Depends
+      "libboost-all-dev" -> "libboost-python-dev"[color=blue];  // Depends
+      "libboost-all-dev" -> "libboost-mpi-python-dev"[color=blue];  // Depends
+      "libboost-python-dev" -> "libboost-python1.65-dev"[color=blue];  // Depends
+      "libboost-mpi-python1.65-dev" -> "libboost-mpi-python1.65.1"[color=blue];  // Depends
+    }
+
 
 
 By default this looks for dependencies on the debian package named **python**.
@@ -35,4 +73,23 @@ Use **--quiet** to suppress warnings and human readable output.
 
 ::
 
-    py3-ready check-apt --quiet libboost-python-dev
+    py3-ready check-apt --dot --quiet libboost-python-dev
+
+Output
+%%%%%%
+
+::
+
+    $ py3-ready check-apt --dot --quiet libboost-all-dev
+    digraph G {
+      "libboost-mpi-python1.65.1" -> "python:any"[color=blue];  // Depends
+      "libboost-mpi-python1.65-dev" -> "libboost-mpi-python1.65.1"[color=blue];  // Depends
+      "libboost-python1.65-dev" -> "python-dev"[color=blue];  // Depends
+      "libboost-all-dev" -> "libboost-mpi-python-dev"[color=blue];  // Depends
+      "libboost-all-dev" -> "libboost-python-dev"[color=blue];  // Depends
+      "libboost-python-dev" -> "libboost-python1.65-dev"[color=blue];  // Depends
+      "python:any" -> "python"[color=green];  // virtual
+      "libboost-mpi-python1.65.1" -> "python"[color=blue];  // Depends
+      "python-dev" -> "python"[color=blue];  // Depends
+      "libboost-mpi-python-dev" -> "libboost-mpi-python1.65-dev"[color=blue];  // Depends
+    }

--- a/README.rst
+++ b/README.rst
@@ -15,23 +15,11 @@ It exits with code 1 if the package does depend on python 2, otherwise the exit 
 
 ::
 
-    py3-ready check-apt libboost-python-dev
-
-Output
-
-::
-
     $ py3-ready check-apt libboost-python-dev
     libboost-python-dev depends on python
 
 
 Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org/doc/info/lang.html>`_ format.
-
-::
-
-    py3-ready check-apt --dot libboost-all-dev
-
-Output
 
 ::
 
@@ -63,17 +51,13 @@ Output
 By default this looks for dependencies on the debian package named **python**.
 Use **--target** to change this name.
 
+
 ::
 
-    py3-ready check-apt --target python3 libboost-all-dev
+    $ py3-ready check-apt --target python3 python3-apt     
+    python3-apt depends on python3
 
 Use **--quiet** to suppress warnings and human readable output.
-
-::
-
-    py3-ready check-apt --dot --quiet libboost-python-dev
-
-Output
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,37 @@
+=========
+py3-ready
+=========
+
+This is a tool for checking if your ROS package or its dependencies depend on python 2.
+
+Usage
+^^^^^
+
+check-apt
+:::::::::
+
+This checks uses **apt** to check if a debian package recursively depends on python 2.
+It exits with code 0 if the package does not depend on python2.
+The exit code is 1 if it does depend on python.
+
+::
+
+    py3-ready check-apt libboost-python-dev
+
+Passing **--dot** outputs the dependency graph in `DOT https://www.graphviz.org/doc/info/lang.html`_ format.
+
+::
+    py3-ready check-apt --dot libboost-all-dev
+
+
+By default this looks for dependencies on the debian package named **python**.
+Use **--target** to change which package to look for recursive dependency.
+
+::
+    py3-ready check-apt --target python3 libboost-all-dev
+
+Use **--quiet** to suppress warnings and human readable output.
+
+::
+
+    py3-ready check-apt --quiet libboost-python-dev

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,8 @@ Usage
 check-apt
 :::::::::
 
-This checks uses **apt** to check if a debian package recursively depends on python 2.
-It exits with code 0 if the package does not depend on python2.
-The exit code is 1 if it does depend on python.
+This uses **apt** to check if a debian package recursively depends on python 2.
+It exits with code 1 if the package does depend on python 2, otherwise the exit code is 0.
 
 ::
 

--- a/py3_ready/apt_tracer.py
+++ b/py3_ready/apt_tracer.py
@@ -1,0 +1,137 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for walking through and tracing debian package dependencies.""" 
+
+import copy
+import sys
+
+from .dependency_tracer import DependencyTracer
+from .dot import paths_to_dot
+
+from apt.cache import Cache
+from apt.package import Package
+
+
+class AptTracer(DependencyTracer):
+
+    def __init__(self, cache=None, quiet=True):
+        if not cache:
+            cache = Cache()
+        self._cache = cache
+        self._quiet = quiet
+
+    def trace_paths(self, start: str, target: str):
+        start = self._cache.get(start)
+        target = self._cache.get(target)
+        self._visited_nodes = []
+        self._nodes_to_target = set([])
+        self._edges_to_target = []
+        # Descend through dependency
+        if self._trace_path(start, target):
+            self._edges_to_target.append((start.name, None, None))
+            self._nodes_to_target.add(start.name)
+        # TODO(sloretz) why are edges sometimes repeated?
+        return list(set(self._edges_to_target))
+
+    def _trace_path(self, start, target):
+        """Depth first search to trace paths to target."""
+        if start.name in self._visited_nodes:
+            return start.name in self._nodes_to_target
+        self._visited_nodes.append(start.name)
+        if start.name == target.name:
+            # Found target, add path to paths
+            return True
+        if not start.candidate.dependencies:
+            # lowest level and target not found
+            return False
+        leads_to_target = False
+        for dependency in start.candidate.dependencies:
+            rawtype = dependency.rawtype
+            # Check all the candidates that can satisfy this dependency
+            for base_dep in dependency:
+                # Only walk upstream dependencies
+                if base_dep.rawtype in ['Depends', 'PreDepends', 'Suggests', 'Recommends']:
+                    if self._cache.is_virtual_package(base_dep.name):
+                        for pkg in self._cache.get_providing_packages(base_dep.name):
+                            if self._trace_path(pkg, target):
+                                leads_to_target = True
+                                edge1 = (start.name, base_dep.name, base_dep.rawtype)
+                                edge2 = (base_dep.name, pkg.name, 'virtual')
+                                self._edges_to_target.append(edge1)
+                                self._edges_to_target.append(edge2)
+                                self._nodes_to_target.add(base_dep.name)
+                    else:
+                        pkg = self._cache.get(base_dep.name)
+                        if pkg is None:
+                            if not self._quiet:
+                                sys.stderr.write(
+                                    "'{}' not in apt cache. Used by '{}' as '{}'\n".format(
+                                        base_dep.name, start.name, dependency))
+                            continue
+                        if self._trace_path(pkg, target):
+                            leads_to_target = True
+                            edge = (start.name, pkg.name, base_dep.rawtype)
+                            self._edges_to_target.append(edge)
+                            self._nodes_to_target.add(base_dep.name)
+        return leads_to_target
+
+
+APT_EDGE_LEGEND = {
+    'virtual': '[color=green]',
+    'Depends': '[color=blue]',
+    'PreDepends': '[color=blue]',
+    'Suggests': '[color=yellow]',
+    'Recommends': '[color=yellow]',
+}
+
+
+class AptTracerCommand:
+
+    COMMAND_NAME='check-apt'
+    COMMAND_HELP='check if apt package depends on python 2'
+
+    def __init__(self, parser):
+        # arguments for start, target, quiet, and dot output
+        # Add arguments to arg-parser
+        parser.add_argument(
+            'pkg', type=str,
+            help='Name of package to check for dependency on python 2')
+        parser.add_argument('--quiet', action='store_true')
+        parser.add_argument(
+            '--dot', action='store_true', help='output DOT graph')
+        parser.add_argument(
+            '--target', default='python',
+            help='Package to trace to (default python)')
+
+    def do_command(self, args):
+        start = args.pkg
+        target = args.target
+
+        tracer = AptTracer(quiet=args.quiet)
+
+        paths = tracer.trace_paths(start, target)
+        if args.dot:
+            print(paths_to_dot(paths, edge_legend=APT_EDGE_LEGEND))
+        elif not args.quiet:
+            if paths:
+                print('{} depends on {}'.format(start, target))
+            else:
+                print('{} does not depend on {}'.format(start, target))
+
+        if paths:
+            # non-zero exit code to indicate it does depend on target
+            # because it's assumed depending on target is undesirable
+            return 1
+        return 0

--- a/py3_ready/cli.py
+++ b/py3_ready/cli.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import argparse
+
+from .apt_tracer import AptTracerCommand
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    cmd_classes = [
+        AptTracerCommand
+    ]
+
+    for cmd_class in cmd_classes:
+        sub_parser = subparsers.add_parser(
+            cmd_class.COMMAND_NAME, help=cmd_class.COMMAND_HELP)
+        cmd = cmd_class(sub_parser)
+        sub_parser.set_defaults(func=cmd.do_command)
+
+    args = parser.parse_args()
+    if not hasattr(args, 'func'):
+        parser.print_usage()
+    else:
+        sys.exit(args.func(args))

--- a/py3_ready/dependency_tracer.py
+++ b/py3_ready/dependency_tracer.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Interface for tracing package dependencies.""" 
+
+
+class DependencyTracer:
+
+    def trace_paths(self, start: str, target: str):
+        raise NotImplementedError()

--- a/py3_ready/dot.py
+++ b/py3_ready/dot.py
@@ -1,0 +1,31 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def paths_to_dot(paths, edge_legend=None):
+    """Given dependency paths, output in dot format for graphviz."""
+    if edge_legend is None:
+        edge_legend = {}
+    edges = []
+    for edge in paths:
+        start, end, rawtype = edge
+        style = ''
+        if not start or not end:
+            continue
+        if rawtype in edge_legend:
+            style = edge_legend[rawtype]
+        edges.append('  "{beg}" -> "{end}"{style};  // {rawtype}\n'.format(
+            beg=start, end=end, style=style, rawtype=rawtype))
+
+    return 'digraph G {{\n{edges}}}'.format(edges=''.join(edges))

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,9 @@
 
 from setuptools import setup
 
+with open("README.rst", "r") as fin:
+  long_description = fin.read()
+
 setup(
     name='py3-ready',
     version='0.1.0',
@@ -32,6 +35,8 @@ setup(
         'License :: OSI Approved :: Apache Software License'
     ],
     description='A tool to identify dependencies on python 2.',
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
     license='Apache License 2.0',
     install_requires=[],  # TODO(sloretz) what to do if deps are debian packages?
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup
+
+setup(
+    name='py3-ready',
+    version='0.1.0',
+    packages=['py3_ready'],
+    entry_points={
+        'console_scripts': [
+            'py3-ready = py3_ready.cli:main',
+	    ]
+    },
+    author='Shane Loretz',
+    author_email='sloretz@openrobotics.org',
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 2',
+        'License :: OSI Approved :: Apache Software License'
+    ],
+    description='A tool to identify dependencies on python 2.',
+    license='Apache License 2.0',
+    install_requires=[],  # TODO(sloretz) what to do if deps are debian packages?
+)


### PR DESCRIPTION
Adds `py3-ready check-apt` for checking if an apt package depends on python2


Examples
```
$  py3-ready check-apt python3
python3 does not depend on python
```

```
$ py3-ready check-apt --quiet --dot libgazebo9-dev
digraph G {
  "libboost-mpi-python1.65.1" -> "python"[color=blue];  // Depends
  "libboost-mpi-python1.65.1" -> "python:any"[color=blue];  // Depends
  "libboost-python1.65-dev" -> "python-dev"[color=blue];  // Depends
  "libgazebo9-dev" -> "libboost-all-dev"[color=blue];  // Depends
  "libboost-mpi-python-dev" -> "libboost-mpi-python1.65-dev"[color=blue];  // Depends
  "libboost-all-dev" -> "libboost-python-dev"[color=blue];  // Depends
  "libboost-mpi-python1.65-dev" -> "libboost-mpi-python1.65.1"[color=blue];  // Depends
  "python-dev" -> "python"[color=blue];  // Depends
  "libboost-python-dev" -> "libboost-python1.65-dev"[color=blue];  // Depends
  "libboost-all-dev" -> "libboost-mpi-python-dev"[color=blue];  // Depends
  "python:any" -> "python"[color=green];  // virtual
}
```