### PR TITLE
Fix invalid apt keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,13 @@ This is a tool for checking if your ROS package or its dependencies depend on py
 
 Usage
 ^^^^^
+All commands exit with code 1 if the package does depend on python 2, and 0 if does not.
+If any unrecoverable error occurs then the exit code is 2.
+
 check-rosdep
 :::::::::
 
 This uses **rosdep** and **apt** to check if a rosdep key recursively depends on python 2.
-It exits with code 1 if the package does depend on python 2, otherwise the exit code is 0.
 
 ::
 
@@ -50,7 +52,6 @@ check-apt
 :::::::::
 
 This uses **apt** to check if a debian package recursively depends on python 2.
-It exits with code 1 if the package does depend on python 2, otherwise the exit code is 0.
 
 ::
 

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -138,7 +138,10 @@ class CheckRosdepCommand:
         for apt_depend in apt_depends:
             tracer = AptTracer(quiet=args.quiet)
 
-            paths = tracer.trace_paths(apt_depend, target)
+            try:
+                paths = tracer.trace_paths(apt_depend, target)
+            except KeyError:
+                return 2
 
             if paths:
                 start_pkg = None


### PR DESCRIPTION
Print a message if the start or target apt keys are not in the cache. Also clarify return code in documentation