### PR TITLE
Check package xml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,92 @@ Usage
 All commands exit with code 1 if the package does depend on python 2, and 0 if does not.
 If any unrecoverable error occurs then the exit code is 2.
 
+check-package-xml
+:::::::::::::::::
+
+This uses **rospack**, **rosdep**, and **apt** to check if any dependency of a ROS package depends on python2.
+The command takes a path to a `package.xml` file or directory containing one.
+Use **--quiet** to suppress warnings and human readable output.
+
+::
+
+
+    $ py3-ready check-package-xml $(rospack find catkin)
+    python-argparse did not resolve to an apt package
+    /opt/ros/melodic/share/catkin depends on python
+
+Passing **--dot** outputs the dependency graph in `DOT <https://www.graphviz.org/doc/info/lang.html>`_ format.
+
+::
+
+    $ py3-ready check-package-xml --quiet --dot $(rospack find genmsg)
+    digraph G {
+      "python-catkin-pkg" -> "python-pyparsing"[color=blue];  // Depends
+      "pkg: genmsg" -> "pkg: catkin"[color=pink];  // buildtool_depend
+      "python-pbr" -> "python-pkg-resources"[color=blue];  // Depends
+      "pkg: genmsg" -> "rosdep: python-empy"[color=pink];  // exec_depend
+      "pkg: genmsg" -> "pkg: catkin"[color=pink];  // exec_depend
+      "pkg: genmsg" -> "rosdep: python-empy"[color=pink];  // build_export_depend
+      "python-roman" -> "python:any"[color=blue];  // Depends
+      "python-catkin-pkg-modules" -> "python-pyparsing"[color=blue];  // Depends
+      "pkg: catkin" -> "rosdep: python-nose"[color=pink];  // test_depend
+      "pkg: catkin" -> "rosdep: google-mock"[color=pink];  // build_export_depend
+      "python-pbr" -> "python:any"[color=blue];  // Depends
+      "python-nose" -> "python:any"[color=blue];  // Depends
+      "pkg: catkin" -> "rosdep: python-mock"[color=pink];  // test_depend
+      "pkg: genmsg" -> "pkg: catkin"[color=pink];  // build_export_depend
+      "python-dateutil" -> "python:any"[color=blue];  // Depends
+      "rosdep: python-nose" -> "python-nose"[color=orange];  // rosdep
+      "pkg: catkin" -> "rosdep: python-catkin-pkg"[color=pink];  // exec_depend
+      "python-empy" -> "python"[color=blue];  // Depends
+      "python-funcsigs" -> "python:any"[color=blue];  // Depends
+      "python-catkin-pkg-modules" -> "python:any"[color=blue];  // Depends
+      "python-mock" -> "python-pbr"[color=blue];  // Depends
+      "python-catkin-pkg" -> "python-dateutil"[color=blue];  // Depends
+      "rosdep: google-mock" -> "google-mock"[color=orange];  // rosdep
+      "python-nose" -> "python-pkg-resources"[color=blue];  // Depends
+      "python-catkin-pkg" -> "python:any"[color=blue];  // Depends
+      "pkg: catkin" -> "rosdep: python-catkin-pkg"[color=pink];  // build_export_depend
+      "python-catkin-pkg-modules" -> "python-dateutil"[color=blue];  // Depends
+      "python-catkin-pkg" -> "python-docutils"[color=blue];  // Depends
+      "googletest" -> "python:any"[color=blue];  // Depends
+      "rosdep: python-mock" -> "python-mock"[color=orange];  // rosdep
+      "pkg: catkin" -> "rosdep: python-nose"[color=pink];  // build_export_depend
+      "python-pkg-resources" -> "python:any"[color=blue];  // Depends
+      "python-docutils" -> "python-roman"[color=blue];  // Depends
+      "python-catkin-pkg" -> "python-catkin-pkg-modules"[color=blue];  // Depends
+      "rosdep: gtest" -> "libgtest-dev"[color=orange];  // rosdep
+      "python-six" -> "python:any"[color=blue];  // Depends
+      "python-docutils" -> "python:any"[color=blue];  // Depends
+      "python-catkin-pkg-modules" -> "python-docutils"[color=blue];  // Depends
+      "python-mock" -> "python-six"[color=blue];  // Depends
+      "rosdep: python-catkin-pkg" -> "python-catkin-pkg"[color=orange];  // rosdep
+      "pkg: catkin" -> "rosdep: gtest"[color=pink];  // build_export_depend
+      "python-mock" -> "python:any"[color=blue];  // Depends
+      "pkg: catkin" -> "rosdep: python-catkin-pkg"[color=pink];  // build_depend
+      "pkg: catkin" -> "rosdep: python-empy"[color=pink];  // build_depend
+      "rosdep: python-empy" -> "python-empy"[color=orange];  // rosdep
+      "python-empy" -> "python:any"[color=blue];  // Depends
+      "python-pyparsing" -> "python:any"[color=blue];  // Depends
+      "google-mock" -> "googletest"[color=blue];  // Depends
+      "python-dateutil" -> "python-six"[color=blue];  // Depends
+      "python-pbr" -> "python-six"[color=blue];  // Depends
+      "python:any" -> "python"[color=green];  // virtual
+      "pkg: catkin" -> "rosdep: python-empy"[color=pink];  // build_export_depend
+      "libgtest-dev" -> "googletest"[color=blue];  // Depends
+      "python-mock" -> "python-funcsigs"[color=blue];  // Depends
+    }
+
+By default this looks for dependencies on the debian package named **python**.
+Use **--target** to change this name.
+
+::
+
+    $ py3-ready check-package-xml --target python3 $(rospack find gazebo_ros) 2>/dev/null
+    /opt/ros/melodic/share/gazebo_ros depends on python3
+
 check-rosdep
-:::::::::
+::::::::::::
 
 This uses **rosdep** and **apt** to check if a rosdep key recursively depends on python 2.
 

--- a/py3_ready/apt_tracer.py
+++ b/py3_ready/apt_tracer.py
@@ -33,6 +33,7 @@ class AptTracer(DependencyTracer):
             cache = Cache()
         self._cache = cache
         self._quiet = quiet
+        self._last_target = None
 
     def trace_paths(self, start, target):
         start_pkg = self._cache.get(start)
@@ -47,9 +48,13 @@ class AptTracer(DependencyTracer):
             if not self._quiet:
                 sys.stderr.write(msg + '\n')
             raise KeyError(msg)
-        self._visited_nodes = []
-        self._nodes_to_target = set([])
-        self._edges_to_target = []
+
+        if target != self._last_target:
+            self._last_target = target
+            # Reuse cache if target is the same
+            self._visited_nodes = []
+            self._nodes_to_target = set([])
+            self._edges_to_target = []
         # Descend through dependency
         if self._trace_path(start_pkg, target_pkg):
             self._edges_to_target.append((start, None, None))

--- a/py3_ready/cli.py
+++ b/py3_ready/cli.py
@@ -17,6 +17,7 @@ import argparse
 
 from .apt_tracer import AptTracerCommand
 from .rosdep import CheckRosdepCommand
+from .package_xml import CheckPackageXMLCommand
 
 def main():
     parser = argparse.ArgumentParser()
@@ -24,7 +25,8 @@ def main():
 
     cmd_classes = [
         AptTracerCommand,
-        CheckRosdepCommand
+        CheckRosdepCommand,
+        CheckPackageXMLCommand
     ]
 
     for cmd_class in cmd_classes:

--- a/py3_ready/package_xml.py
+++ b/py3_ready/package_xml.py
@@ -58,6 +58,11 @@ class PackageXMLTracer(DependecyTracer):
             return start.name in self._pkgs_to_target
 
         # TODO(sloretz) for each dep, is it a package or rosdep key?
+        # if it's a rosdep key, ask rosdep to resolve it for us
+        # then use AptTracer to get the apt dependencies for it
+        # if it's a ros package then call _trace_path on it to do the same
+        # if it returns true then we depend on py2 because the ros package does
+        # too
 
 
 PACKAGE_XML_EDGE_LEGEND = {

--- a/py3_ready/package_xml.py
+++ b/py3_ready/package_xml.py
@@ -1,0 +1,131 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for checking dependencies of package.xml files."""
+
+import os
+import sys
+
+from .apt_tracer import APT_EDGE_LEGEND
+from .apt_tracer import AptTracer
+from .dependency_tracer import DependencyTracer
+from .dot import paths_to_dot
+from .rosdep import is_rosdep_initialized
+
+from apt.cache import Cache
+from catkin_pkg.package import parse_package
+
+
+class PackageXMLTracer(DependecyTracer):
+
+    def __init__(self, cache=None, quiet=True):
+        if not cache:
+            cache = Cache()
+        self._cache = cache
+        self._quiet = quiet
+
+    def trace_paths(self, start: str, target: str):
+        # start: path to a ROS package
+        # target: name of a debian package
+
+        self._visited_pkgs = []
+        self._pkgs_to_target = set([])
+        self._edges_to_target = []
+
+        # TODO(sloretz) must recursively trace package.xml files here
+        # because one package could depend on another package in the system
+        # rospack can find them
+        # each key can be a ros package or a rosdep key, and paths from both need to be merged
+        # graph nodes should be rosdep: for rosdep keys and rospkg for ros packages
+        # ros packages will need a legend for each type of dependency
+        pass
+        # TODO(sloretz) return list of 3-tuples (start: str, end: str, type: str)
+
+    def _trace_path(self, start, target):
+        """return true if path leads to target"""
+        if start.name in self._visited_pkgs:
+            return start.name in self._pkgs_to_target
+
+        # TODO(sloretz) for each dep, is it a package or rosdep key?
+
+
+PACKAGE_XML_EDGE_LEGEND = {
+  'build_depend': '[color=pink]',
+  'buildtool_depend': '[color=pink]',
+  'build_export_depend': '[color=pink]',
+  'buildtool_export_depend': '[color=pink]',
+  'exec_depend': '[color=pink]',
+  'test_depend': '[color=pink]',
+  'doc_depend': '[color=pink]',
+}
+
+
+class CheckPackageXMLCommand:
+    COMMAND_NAME='check-package-xml'
+    COMMAND_HELP='check if dependencies in a package.xml depend on python 2'
+
+    def __init__(self, parser):
+        # arguments for key, quiet, and dot output
+        parser.add_argument(
+            'path', type=str,
+            help='path to package.xml file to check')
+        parser.add_argument('--quiet', action='store_true')
+        parser.add_argument(
+            '--dot', action='store_true', help='output DOT graph')
+        parser.add_argument(
+            '--target', default='python',
+            help='Debian package to trace to (default python)')
+        # TODO option to output just the rosdep keys that depend on python
+
+    def do_command(self, args):
+        if not is_rosdep_initialized():
+            sys.stderr.write(
+                'The rosdep database is not ready to be used. '
+                'Run \n\n\trosdep resolve {}\n\n'
+                'for instructions on how to fix this.\n'.format(
+                    args.key))
+            return 2
+
+        all_paths = []
+
+        try:
+            package = parse_package(args.path)
+        except OSError as e:
+            sys.stderr.write(str(e) + '\n')
+            return 2
+
+        # print(package)
+        print(package.build_depends)
+        print(package.buildtool_depends)
+        print(package.build_export_depends)
+        print(package.buildtool_export_depends)
+        print(package.exec_depends)
+        print(package.test_depends)
+        print(package.doc_depends)
+        # print(package.group_depends)  # Are these evaluated?
+
+        # for each type of dependency
+        #   what kind of package is it?
+        #       is it a rosdep key?
+        #       Is it a ros package?
+        #           I think I need to use rospack to determine this
+        #           rospack find <package>
+        #           Also this ros workspace needs to be sourced
+        print(package.build_depends[0].name)
+
+        if all_paths:
+            # non-zero exit code to indicate it does depend on target
+            # because it's assumed depending on target is undesirable
+            return 1
+        return 0

--- a/py3_ready/package_xml.py
+++ b/py3_ready/package_xml.py
@@ -127,7 +127,6 @@ class PackageXMLTracer(DependencyTracer):
                     self._pkgs_to_target.add(start.name)
                     leads_to_target = True
 
-        # print(start.name, leads_to_target)
         return leads_to_target
 
 
@@ -158,7 +157,6 @@ class CheckPackageXMLCommand(object):
         parser.add_argument(
             '--target', default='python',
             help='Debian package to trace to (default python)')
-        # TODO option to output just the rosdep keys that depend on python
 
     def do_command(self, args):
         all_paths = []

--- a/py3_ready/package_xml.py
+++ b/py3_ready/package_xml.py
@@ -114,6 +114,7 @@ class PackageXMLTracer(DependencyTracer):
                     self._edges_to_target.append(first_edge)
                     self._edges_to_target.extend(rosdep_paths)
                     self._pkgs_to_target.add(start.name)
+                    self._rosdeps_to_target.add(dep.name)
                     leads_to_target = True
             else:
                 pkg = parse_package(self._rospack.get_path(dep.name))

--- a/py3_ready/package_xml.py
+++ b/py3_ready/package_xml.py
@@ -25,39 +25,91 @@ from .rosdep import is_rosdep_initialized
 
 from apt.cache import Cache
 from catkin_pkg.package import parse_package
+from rospkg import RosPack
+from rospkg.common import PACKAGE_FILE
+from rospkg.common import MANIFEST_FILE
+from rospkg.manifest import InvalidManifest
+from rospkg.manifest import parse_manifest_file
 
 
-class PackageXMLTracer(DependecyTracer):
+def get_rospack_manifest(path, rospack):
+    if path.endswith(PACKAGE_FILE):
+        path = os.path.dirname(path)
+    print(path)
+    # TODO(sloretz) why does this raise with PACKAGE_FILE?
+    return parse_manifest_file(path, MANIFEST_FILE, rospack=rospack)
+
+
+def get_rosdeps(pkg, rospack):
+    m = get_rospack_manifest(pkg.filename, rospack)
+    rosdeps = m.rosdeps
+    return [r.name for r in rosdeps]
+
+
+class PackageXMLTracer(DependencyTracer):
 
     def __init__(self, cache=None, quiet=True):
         if not cache:
             cache = Cache()
         self._cache = cache
         self._quiet = quiet
+        self._rospack = RosPack()
 
-    def trace_paths(self, start: str, target: str):
+    def trace_paths(self, start, target):
         # start: path to a ROS package
         # target: name of a debian package
+        start_pkg = parse_package(start)
 
         self._visited_pkgs = []
         self._pkgs_to_target = set([])
         self._edges_to_target = []
-
         # TODO(sloretz) must recursively trace package.xml files here
         # because one package could depend on another package in the system
         # rospack can find them
         # each key can be a ros package or a rosdep key, and paths from both need to be merged
         # graph nodes should be rosdep: for rosdep keys and rospkg for ros packages
         # ros packages will need a legend for each type of dependency
-        pass
+        if self._trace_path(start_pkg, target):
+            self._edges_to_target.append((start, None, None))
+            self._nodes_to_target.add(start)
+        return list(set(self._edges_to_target))
         # TODO(sloretz) return list of 3-tuples (start: str, end: str, type: str)
 
     def _trace_path(self, start, target):
-        """return true if path leads to target"""
+        """return true if path leads to target debian package"""
         if start.name in self._visited_pkgs:
             return start.name in self._pkgs_to_target
 
+        rosdep_keys = get_rosdeps(start, self._rospack)
+
+        depends = []
+        for dep in start.build_depends:
+            depends.append((dep, 'build_depend'))
+        for dep in start.buildtool_depends:
+            depends.append((dep, 'buildtool_depend'))
+        for dep in start.build_export_depends:
+            depends.append((dep, 'build_export_depend'))
+        for dep in start.buildtool_export_depends:
+            depends.append((dep, 'buildtool_export_depend'))
+        for dep in start.exec_depends:
+            depends.append((dep, 'exec_depend'))
+        for dep in start.test_depends:
+            depends.append((dep, 'test_depend'))
+        for dep in start.doc_depends:
+            depends.append((dep, 'doc_depend'))
+        for dep in start.group_depends:
+            depends.append((dep, 'group_depend'))
+
+        for dep, rawtype in depends:
+            if dep.name in rosdep_keys:
+                print(dep.name, "is a rosdep key")
+            else:
+                print(dep.name, "is a ros package at", self._rospack.get_path(dep.name))
+
+        return False
+
         # TODO(sloretz) for each dep, is it a package or rosdep key?
+        # this is what `rospack rosdep0` does
         # if it's a rosdep key, ask rosdep to resolve it for us
         # then use AptTracer to get the apt dependencies for it
         # if it's a ros package then call _trace_path on it to do the same
@@ -73,10 +125,11 @@ PACKAGE_XML_EDGE_LEGEND = {
   'exec_depend': '[color=pink]',
   'test_depend': '[color=pink]',
   'doc_depend': '[color=pink]',
+  'group_depend': '[color=pink]',
 }
 
 
-class CheckPackageXMLCommand:
+class CheckPackageXMLCommand(object):
     COMMAND_NAME='check-package-xml'
     COMMAND_HELP='check if dependencies in a package.xml depend on python 2'
 
@@ -103,31 +156,15 @@ class CheckPackageXMLCommand:
             return 2
 
         all_paths = []
+        tracer = PackageXMLTracer(quiet=args.quiet)
 
         try:
-            package = parse_package(args.path)
+            paths = tracer.trace_paths(args.path, args.target)
         except OSError as e:
             sys.stderr.write(str(e) + '\n')
             return 2
-
-        # print(package)
-        print(package.build_depends)
-        print(package.buildtool_depends)
-        print(package.build_export_depends)
-        print(package.buildtool_export_depends)
-        print(package.exec_depends)
-        print(package.test_depends)
-        print(package.doc_depends)
-        # print(package.group_depends)  # Are these evaluated?
-
-        # for each type of dependency
-        #   what kind of package is it?
-        #       is it a rosdep key?
-        #       Is it a ros package?
-        #           I think I need to use rospack to determine this
-        #           rospack find <package>
-        #           Also this ros workspace needs to be sourced
-        print(package.build_depends[0].name)
+        except KeyError:
+            return 2
 
         if all_paths:
             # non-zero exit code to indicate it does depend on target

--- a/py3_ready/package_xml.py
+++ b/py3_ready/package_xml.py
@@ -56,6 +56,7 @@ class PackageXMLTracer(DependencyTracer):
         self._cache = cache
         self._quiet = quiet
         self._rospack = RosPack()
+        self._tracer = RosdepTracer(cache=self._cache, quiet=self._quiet)
 
     def trace_paths(self, start, target):
         # start: path to a ROS package
@@ -106,8 +107,7 @@ class PackageXMLTracer(DependencyTracer):
                 else:
                     self._visited_rosdeps.append(dep.name)
                     # Trace rosdep key to target
-                    tracer = RosdepTracer(cache=self._cache, quiet=self._quiet)
-                    rosdep_paths = tracer.trace_paths(dep.name, target)
+                    rosdep_paths = self._tracer.trace_paths(dep.name, target)
                     if rosdep_paths:
                         dep_leads_to_target = True
                         self._edges_to_target.extend(rosdep_paths)

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -121,7 +121,8 @@ class RosdepTracer(DependencyTracer):
         all_paths = []
         if not apt_depends:
             if not self._quiet:
-                print('{} might not depend on {}'.format(start, target))
+                sys.stderr.write(
+                    '{} did not resolve to an apt package\n'.format(start))
         else:
             for apt_depend in apt_depends:
                 tracer = AptTracer(quiet=self._quiet)

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -21,6 +21,7 @@ import sys
 
 from .apt_tracer import APT_EDGE_LEGEND
 from .apt_tracer import AptTracer
+from .dependency_tracer import DependencyTracer
 from .dot import paths_to_dot
 
 from apt.cache import Cache
@@ -88,6 +89,60 @@ def resolve_rosdep_key(key, quiet=False):
     return {installer: resolved}
 
 
+class RosdepTracer(DependencyTracer):
+
+    def __init__(self, cache=None, quiet=True):
+        if not cache:
+            cache = Cache()
+        self._cache = cache
+        self._quiet = quiet
+
+    def trace_paths(self, start, target):
+        if not is_rosdep_initialized():
+            msg = ('The rosdep database is not ready to be used. '
+                'Run \n\n\trosdep resolve {}\n\n'
+                'for instructions on how to fix this.\n'.format(start))
+            if not self._quiet:
+                print(msg)
+            raise KeyError(msg)
+
+        resolved = resolve_rosdep_key(start)
+        if resolved is None:
+            msg = 'Could not resolve rosdep key {}\n'.format(start)
+            if not self._quiet:
+                print(msg)
+            raise KeyError(msg)
+
+        apt_depends = []
+        for installer, pkgs in resolved.items():
+            if isinstance(installer, AptInstaller):
+                apt_depends = pkgs
+
+        all_paths = []
+        if not apt_depends:
+            if not self._quiet:
+                print('{} might not depend on {}'.format(apt.key, target))
+        else:
+            for apt_depend in apt_depends:
+                tracer = AptTracer(quiet=self._quiet)
+
+                paths = tracer.trace_paths(apt_depend, target)
+                if paths:
+                    start_pkg = None
+                    for edge in paths:
+                        if edge[1] is None:
+                            start_pkg = edge[0]
+                            break
+                    first_edge = (
+                        'rosdep: ' + start,
+                        start_pkg,
+                        'rosdep'
+                    )
+                    paths.append(first_edge)
+                    all_paths.extend(paths)
+        return all_paths
+
+
 ROSDEP_EDGE_LEGEND = {
     'rosdep': '[color=orange]',
 }
@@ -110,54 +165,12 @@ class CheckRosdepCommand:
             help='Debian package to trace to (default python)')
 
     def do_command(self, args):
-        if not is_rosdep_initialized():
-            sys.stderr.write(
-                'The rosdep database is not ready to be used. '
-                'Run \n\n\trosdep resolve {}\n\n'
-                'for instructions on how to fix this.\n'.format(
-                    args.key))
+        tracer = RosdepTracer(quiet=args.quiet)
+
+        try:
+            all_paths = tracer.trace_paths(args.key, args.target)
+        except KeyError:
             return 2
-
-        resolved = resolve_rosdep_key(args.key)
-        if resolved is None:
-            return 2
-
-        apt_depends = []
-
-        for installer, pkgs in resolved.items():
-            if isinstance(installer, AptInstaller):
-                apt_depends = pkgs
-
-        target = args.target
-
-        if not apt_depends:
-            if not args.quiet:
-                print('{} might not depend on {}'.format(apt.key, target))
-
-        all_paths = []
-        cache = Cache()
-
-        for apt_depend in apt_depends:
-            tracer = AptTracer(quiet=args.quiet)
-
-            try:
-                paths = tracer.trace_paths(apt_depend, target)
-            except KeyError:
-                return 2
-
-            if paths:
-                start_pkg = None
-                for edge in paths:
-                    if edge[1] is None:
-                        start_pkg = edge[0]
-                        break
-                first_edge = (
-                    'rosdep: ' + args.key,
-                    start_pkg,
-                    'rosdep'
-                )
-                paths.append(first_edge)
-                all_paths.extend(paths)
 
         if args.dot:
             legend = {}
@@ -166,10 +179,9 @@ class CheckRosdepCommand:
             print(paths_to_dot(list(set(all_paths)), edge_legend=legend))
         elif not args.quiet:
             if all_paths:
-                print('rosdep key {} depends on {}'.format(args.key, target))
+                print('rosdep key {} depends on {}'.format(args.key, args.target))
             else:
-                # TODO
-                print('rosdep key {} does not depend on {}'.format(args.key, target))
+                print('rosdep key {} does not depend on {}'.format(args.key, args.target))
 
         if all_paths:
             # non-zero exit code to indicate it does depend on target

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -121,7 +121,7 @@ class RosdepTracer(DependencyTracer):
         all_paths = []
         if not apt_depends:
             if not self._quiet:
-                print('{} might not depend on {}'.format(apt.key, target))
+                print('{} might not depend on {}'.format(start, target))
         else:
             for apt_depend in apt_depends:
                 tracer = AptTracer(quiet=self._quiet)

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -96,6 +96,7 @@ class RosdepTracer(DependencyTracer):
             cache = Cache()
         self._cache = cache
         self._quiet = quiet
+        self._tracer = AptTracer(quiet=self._quiet)
 
     def trace_paths(self, start, target):
         if not is_rosdep_initialized():
@@ -125,9 +126,7 @@ class RosdepTracer(DependencyTracer):
                     '{} did not resolve to an apt package\n'.format(start))
         else:
             for apt_depend in apt_depends:
-                tracer = AptTracer(quiet=self._quiet)
-
-                paths = tracer.trace_paths(apt_depend, target)
+                paths = self._tracer.trace_paths(apt_depend, target)
                 if paths:
                     start_pkg = None
                     for edge in paths:


### PR DESCRIPTION
Add command that checks a package.xml for python dependencies. This required refactoring the rosdep command so code could be reused. This also makes Tracer classes cache more aggressively, even between calls to `trace_paths`. This shortens the runtime considerably (35 sec for gazebo_ros to 5 sec)