### PR TITLE
Better caching

### DIFF
--- a/py3_ready/apt_tracer.py
+++ b/py3_ready/apt_tracer.py
@@ -56,7 +56,8 @@ class AptTracer(DependencyTracer):
         self._edges_to_target = []
         self._deferred_pkgs = set()
         if not cache:
-            self._cache = TracerCache()
+            cache = TracerCache()
+        self._cache = cache
 
         # Descend through dependency
         self._trace_path(start_pkg, target_pkg)

--- a/py3_ready/apt_tracer.py
+++ b/py3_ready/apt_tracer.py
@@ -20,81 +20,99 @@ import copy
 import sys
 
 from .dependency_tracer import DependencyTracer
+from .dependency_tracer import Edge
+from .dependency_tracer import Node
+from .dependency_tracer import TracerCache
 from .dot import paths_to_dot
 
 from apt.cache import Cache
 from apt.package import Package
 
+APT_NODE = 'apt'
+
 
 class AptTracer(DependencyTracer):
 
-    def __init__(self, cache=None, quiet=True):
-        if not cache:
-            cache = Cache()
-        self._cache = cache
+    def __init__(self, apt_cache=None, quiet=True):
+        if not apt_cache:
+            apt_cache = Cache()
+        self._apt_cache = apt_cache
         self._quiet = quiet
-        self._last_target = None
 
-    def trace_paths(self, start, target):
-        start_pkg = self._cache.get(start)
+    def trace_paths(self, start, target, cache=None):
+        start_pkg = self._apt_cache.get(start)
         if start_pkg is None:
             msg = "'{}' not in apt cache.".format(start)
             if not self._quiet:
                 sys.stderr.write(msg + '\n')
             raise KeyError(msg)
-        target_pkg = self._cache.get(target)
+        target_pkg = self._apt_cache.get(target)
         if target_pkg is None:
             msg = "'{}' not in apt cache.".format(target)
             if not self._quiet:
                 sys.stderr.write(msg + '\n')
             raise KeyError(msg)
 
-        if target != self._last_target:
-            self._last_target = target
-            # Reuse cache if target is the same
-            self._visited_nodes = []
-            self._nodes_to_target = set([])
-            self._edges_to_target = []
+        self._edges_to_target = []
+        self._deferred_pkgs = set()
+        if not cache:
+            self._cache = TracerCache()
+
         # Descend through dependency
-        if self._trace_path(start_pkg, target_pkg):
-            self._edges_to_target.append((start, None, None))
-            self._nodes_to_target.add(start)
+        self._trace_path(start_pkg, target_pkg)
+        # Need extra passes for circular dependencies
+        while self._deferred_pkgs:
+            def_pkgs = self._deferred_pkgs
+            self._deferred_pkgs = set()
+            for def_pkg in def_pkgs:
+                self._trace_path(def_pkg, target_pkg)
         # TODO(sloretz) why are edges sometimes repeated?
         return list(set(self._edges_to_target))
 
     def _trace_path(self, start, target):
         """Depth first search to trace paths to target."""
-        if start.name in self._visited_nodes:
-            return start.name in self._nodes_to_target
-        self._visited_nodes.append(start.name)
         if start.name == target.name:
-            # Found target, add path to paths
+            # Found target
             return True
+        start_node = Node(start.name, APT_NODE)
+        if self._cache.check_visited(start_node):
+            if self._cache.check_fully_explored(start_node):
+                leads_to_target = self._cache.check_leads_to_target(start_node)
+                if leads_to_target:
+                    self._edges_to_target.extend(self._cache.recursive_edges(start_node))
+                return leads_to_target
+            else:
+                # Defer checks on circular dependencies
+                self._deferred_pkgs.add(start)
+                return False
+        self._cache.visit(start_node)
         if not start.candidate.dependencies:
             # lowest level and target not found
+            self._cache.mark_leads_to_target(start_node, False)
             return False
         leads_to_target = False
         for dependency in start.candidate.dependencies:
-            rawtype = dependency.rawtype
             # Check all the candidates that can satisfy this dependency
             for base_dep in dependency:
                 # Only walk upstream dependencies
                 if base_dep.rawtype in ['Depends', 'PreDepends', 'Suggests', 'Recommends']:
-                    if self._cache.is_virtual_package(base_dep.name):
+                    if self._apt_cache.is_virtual_package(base_dep.name):
                         virtual_to_target = False
-                        for pkg in self._cache.get_providing_packages(base_dep.name):
+                        base_dep_node = Node(base_dep.name, APT_NODE)
+                        for pkg in self._apt_cache.get_providing_packages(base_dep.name):
                             if self._trace_path(pkg, target):
                                 leads_to_target = True
-                                edge1 = (start.name, base_dep.name, base_dep.rawtype)
-                                edge2 = (base_dep.name, pkg.name, 'virtual')
+                                edge1 = Edge(start_node, base_dep.rawtype, base_dep_node)
+                                pkg_node = Node(pkg.name, APT_NODE)
+                                edge2 = Edge(base_dep_node, 'virtual', pkg_node)
+                                self._cache.add_edge(edge1)
+                                self._cache.add_edge(edge2)
                                 self._edges_to_target.append(edge1)
                                 self._edges_to_target.append(edge2)
-                                self._nodes_to_target.add(pkg.name)
                                 virtual_to_target = True
-                        if virtual_to_target:
-                            self._nodes_to_target.add(base_dep.name)
+                        self._cache.mark_leads_to_target(base_dep_node, virtual_to_target)
                     else:
-                        pkg = self._cache.get(base_dep.name)
+                        pkg = self._apt_cache.get(base_dep.name)
                         if pkg is None:
                             if not self._quiet:
                                 sys.stderr.write(
@@ -103,9 +121,11 @@ class AptTracer(DependencyTracer):
                             continue
                         if self._trace_path(pkg, target):
                             leads_to_target = True
-                            edge = (start.name, pkg.name, base_dep.rawtype)
+                            pkg_node = Node(pkg.name, APT_NODE)
+                            edge = Edge(start_node, base_dep.rawtype, pkg_node)
+                            self._cache.add_edge(edge)
                             self._edges_to_target.append(edge)
-                            self._nodes_to_target.add(base_dep.name)
+        self._cache.mark_leads_to_target(start_node, leads_to_target)
         return leads_to_target
 
 

--- a/py3_ready/dependency_tracer.py
+++ b/py3_ready/dependency_tracer.py
@@ -19,3 +19,94 @@ class DependencyTracer(object):
 
     def trace_paths(self, start, target):
         raise NotImplementedError()
+
+
+class Node(object):
+
+    __slots__ = (
+        'name',
+        'node_type'
+    )
+
+    def __init__(self, name, node_type):
+        self.name = name
+        self.node_type = node_type
+
+    def __key(self):
+        return (self.name, self.node_type)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        if isinstance(other, Node):
+            return self.__key() == other.__key()
+        return NotImplemented
+
+
+class Edge(object):
+
+    __slots__ = (
+        'start',
+        'edge_type',
+        'end',
+    )
+
+    def __init__(self, start, edge_type, end):
+        self.start = start
+        self.edge_type = edge_type
+        self.end = end
+
+    def __key(self):
+        return (self.start, self.edge_type, self.end)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        if isinstance(other, Edge):
+            return self.__key() == other.__key()
+        return NotImplemented
+
+
+class TracerCache(object):
+    """Caches edges and dead ends to target."""
+
+    def __init__(self):
+        # Key is (name, rawtype) value is True/False if node leads to target
+        self._visited_nodes = {}  # type: Dict[(str, str), Optional[bool]]
+        self._edges = {}  # type: Dict[(str, str), Set[(str, str)]]
+
+    def visit(self, node):
+        if node not in self._visited_nodes:
+            self._visited_nodes[node] = None
+
+    def check_visited(self, node):
+        if node in self._visited_nodes:
+            return True
+
+    def check_leads_to_target(self, node):
+        if node in self._visited_nodes:
+            return self._visited_nodes[node]
+
+    def check_fully_explored(self, node):
+        if node in self._visited_nodes:
+            return self._visited_nodes[node] is not None
+        return False
+
+    def edges(self, node):
+        if node in self._edges:
+            yield from self._edges[node]
+
+    def recursive_edges(self, node):
+        for edge in self.edges(node):
+            yield edge
+            yield from self.recursive_edges(edge.end)
+
+    def add_edge(self, edge):
+        if edge.start not in self._edges:
+            self._edges[edge.start] = set()
+        self._edges[edge.start].add(edge)
+
+    def mark_leads_to_target(self, node, gets_there):
+        self._visited_nodes[node] = gets_there

--- a/py3_ready/dependency_tracer.py
+++ b/py3_ready/dependency_tracer.py
@@ -99,9 +99,16 @@ class TracerCache(object):
             yield from self._edges[node]
 
     def recursive_edges(self, node):
-        for edge in self.edges(node):
-            yield edge
-            yield from self.recursive_edges(edge.end)
+
+        def _recursive_edges(node, edges):
+            for edge in self.edges(node):
+                if edge not in edges:
+                    edges.add(edge)
+                    _recursive_edges(edge.end, edges)
+
+        edges = set()
+        _recursive_edges(node, edges)
+        yield from edges
 
     def add_edge(self, edge):
         if edge.start not in self._edges:

--- a/py3_ready/dot.py
+++ b/py3_ready/dot.py
@@ -25,9 +25,11 @@ def paths_to_dot(paths, edge_legend=None, node_legend=None):
         style = ''
         if edge.edge_type in edge_legend:
             style = edge_legend[edge.edge_type]
-        edges.append('  "{beg}" -> "{end}"{style};  // {rawtype}\n'.format(
+        edges.append('  "{beg}%{begtype}" -> "{end}%{endtype}"{style};  // {rawtype}\n'.format(
             beg=edge.start.name,
+            begtype=edge.start.node_type,
             end=edge.end.name,
+            endtype=edge.end.node_type,
             style=style,
             rawtype=edge.edge_type))
         nodes.add(edge.start)
@@ -37,7 +39,7 @@ def paths_to_dot(paths, edge_legend=None, node_legend=None):
         style = ''
         if node.node_type in node_legend:
             style = node_legend[node.node_type]
-        node_dot.append('  "{name}"{style};  // {ntype}\n'.format(
+        node_dot.append('  "{name}%{ntype}"{style}[label="{name}"];  // {ntype}\n'.format(
             name=node.name, style=style, ntype=node.node_type))
 
     return 'digraph G {{\n{edges}\n{nodes}}}'.format(

--- a/py3_ready/dot.py
+++ b/py3_ready/dot.py
@@ -19,13 +19,13 @@ def paths_to_dot(paths, edge_legend=None):
         edge_legend = {}
     edges = []
     for edge in paths:
-        start, end, rawtype = edge
         style = ''
-        if not start or not end:
-            continue
-        if rawtype in edge_legend:
-            style = edge_legend[rawtype]
+        if edge.edge_type in edge_legend:
+            style = edge_legend[edge.edge_type]
         edges.append('  "{beg}" -> "{end}"{style};  // {rawtype}\n'.format(
-            beg=start, end=end, style=style, rawtype=rawtype))
+            beg=edge.start.name,
+            end=edge.end.name,
+            style=style,
+            rawtype=edge.edge_type))
 
     return 'digraph G {{\n{edges}}}'.format(edges=''.join(edges))

--- a/py3_ready/dot.py
+++ b/py3_ready/dot.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 
-def paths_to_dot(paths, edge_legend=None):
+def paths_to_dot(paths, edge_legend=None, node_legend=None):
     """Given dependency paths, output in dot format for graphviz."""
     if edge_legend is None:
         edge_legend = {}
+    if node_legend is None:
+        node_legend = {}
     edges = []
+    nodes = set()
     for edge in paths:
         style = ''
         if edge.edge_type in edge_legend:
@@ -27,5 +30,16 @@ def paths_to_dot(paths, edge_legend=None):
             end=edge.end.name,
             style=style,
             rawtype=edge.edge_type))
+        nodes.add(edge.start)
+        nodes.add(edge.end)
+    node_dot = []
+    for node in nodes:
+        style = ''
+        if node.node_type in node_legend:
+            style = node_legend[node.node_type]
+        node_dot.append('  "{name}"{style};  // {ntype}\n'.format(
+            name=node.name, style=style, ntype=node.node_type))
 
-    return 'digraph G {{\n{edges}}}'.format(edges=''.join(edges))
+    return 'digraph G {{\n{edges}\n{nodes}}}'.format(
+        edges=''.join(edges),
+        nodes=''.join(node_dot))

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -151,7 +151,7 @@ ROSDEP_EDGE_LEGEND = {
 }
 
 ROSDEP_NODE_LEGEND = {
-    'rosdep':  '[color=orange,shape=rect]',
+    ROSDEP_NODE:  '[color=orange,shape=rect]',
 }
 
 

--- a/py3_ready/rosdep.py
+++ b/py3_ready/rosdep.py
@@ -20,8 +20,12 @@ import os
 import sys
 
 from .apt_tracer import APT_EDGE_LEGEND
+from .apt_tracer import APT_NODE
 from .apt_tracer import AptTracer
 from .dependency_tracer import DependencyTracer
+from .dependency_tracer import Edge
+from .dependency_tracer import Node
+from .dependency_tracer import TracerCache
 from .dot import paths_to_dot
 
 from apt.cache import Cache
@@ -34,6 +38,9 @@ from rosdep2.sources_list import CACHE_INDEX
 from rosdep2.sources_list import get_sources_cache_dir
 from rosdep2.sources_list import get_sources_list_dir
 from rosdep2.sources_list import SourcesListLoader
+
+
+ROSDEP_NODE = 'rosdep'
 
 
 def is_rosdep_initialized():
@@ -91,14 +98,16 @@ def resolve_rosdep_key(key, quiet=False):
 
 class RosdepTracer(DependencyTracer):
 
-    def __init__(self, cache=None, quiet=True):
-        if not cache:
-            cache = Cache()
-        self._cache = cache
+    def __init__(self, apt_cache=None, quiet=True):
         self._quiet = quiet
-        self._tracer = AptTracer(quiet=self._quiet)
+        self._tracer = AptTracer(apt_cache=apt_cache, quiet=self._quiet)
 
-    def trace_paths(self, start, target):
+    def trace_paths(self, start, target, cache=None):
+        start_node = Node(start, ROSDEP_NODE)
+        if not cache:
+            cache = TracerCache()
+        if cache.check_fully_explored(start_node):
+            return [e for e in cache.recursive_edges(start_node)]
         if not is_rosdep_initialized():
             msg = ('The rosdep database is not ready to be used. '
                 'Run \n\n\trosdep resolve {}\n\n'
@@ -126,25 +135,23 @@ class RosdepTracer(DependencyTracer):
                     '{} did not resolve to an apt package\n'.format(start))
         else:
             for apt_depend in apt_depends:
-                paths = self._tracer.trace_paths(apt_depend, target)
+                paths = self._tracer.trace_paths(apt_depend, target, cache=cache)
                 if paths:
-                    start_pkg = None
-                    for edge in paths:
-                        if edge[1] is None:
-                            start_pkg = edge[0]
-                            break
-                    first_edge = (
-                        'rosdep: ' + start,
-                        start_pkg,
-                        'rosdep'
-                    )
-                    paths.append(first_edge)
+                    apt_node = Node(apt_depend, APT_NODE)
+                    edge = Edge(start_node, 'rosdep', apt_node)
+                    cache.add_edge(edge)
+                    paths.append(edge)
                     all_paths.extend(paths)
+        cache.mark_leads_to_target(start_node, bool(all_paths))
         return all_paths
 
 
 ROSDEP_EDGE_LEGEND = {
     'rosdep': '[color=orange]',
+}
+
+ROSDEP_NODE_LEGEND = {
+    'rosdep':  '[color=orange,shape=rect]',
 }
 
 
@@ -173,10 +180,13 @@ class CheckRosdepCommand:
             return 2
 
         if args.dot:
-            legend = {}
-            legend.update(APT_EDGE_LEGEND)
-            legend.update(ROSDEP_EDGE_LEGEND)
-            print(paths_to_dot(list(set(all_paths)), edge_legend=legend))
+            edge_legend = {}
+            edge_legend.update(APT_EDGE_LEGEND)
+            edge_legend.update(ROSDEP_EDGE_LEGEND)
+            print(
+                paths_to_dot(list(set(all_paths)),
+                edge_legend=edge_legend,
+                node_legend=ROSDEP_NODE_LEGEND))
         elif not args.quiet:
             if all_paths:
                 print('rosdep key {} depends on {}'.format(args.key, args.target))


### PR DESCRIPTION
This adds a class TracerCache that improves how edges and nodes are cached. This greatly speeds up the command and fixes a few bugs with lost edges when there are dependency cycles. Additionally nodes (packages vs rosdep keys vs apt packages) are now styled to differentiate them instead of having prefixes in the labels.