### PR TITLE
Prep for release - Add install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,50 @@ py3-ready
 
 This is a tool for checking if your ROS package or its dependencies depend on python 2.
 
+Install
+^^^^^^^
+
+This package works on Ubuntu and Debian, and it needs some packages installed on the system.
+
+Install these if the default ``python`` is Python 2 (Ubuntu Bionic, Debian Stretch, etc).
+
+::
+
+    $ sudo apt-get install python-apt
+    $ sudo apt-get install python-rosdep-modules
+    $ sudo apt-get install python-catkin-pkg-modules
+
+Install these if the default ``python`` is Python 3 (Ubuntu  focal, Debian Buster, etc).
+
+::
+
+    $ sudo apt-get install python3-apt
+    $ sudo apt-get install python3-rosdep-modules
+    $ sudo apt-get install python3-catkin-pkg-modules
+
+
+Then install from PyPI.org.
+
+::
+
+    $ pip install py3-ready
+
+If you would like to install from source then create a virtual environment with access to system packages.
+
+::
+
+    $ cd py3-ready/
+    # Set up Python 2 virtual environment
+    $ virtualenv --system-site-packages ssenv2
+    $ . ssenv2/bin/activate
+    $ python setup.py develop
+    $ deactivate
+    # Set up Python 3 virtual environment
+    $ python3 venv --system-site-packages ssenv3
+    $ . ssenv3/bin/activate
+    $ python setup.py develop
+
+
 Usage
 ^^^^^
 All commands exit with code 1 if the package does depend on python 2, and 0 if does not.
@@ -18,7 +62,6 @@ The package must exist in a sourced workspace.
 Use **--quiet** to suppress warnings and human readable output.
 
 ::
-
 
     $ py3-ready check-package catkin
     python-argparse did not resolve to an apt package

--- a/py3_ready/cli.py
+++ b/py3_ready/cli.py
@@ -15,11 +15,35 @@
 import sys
 import argparse
 
-from .apt_tracer import AptTracerCommand
-from .rosdep import CheckRosdepCommand
-from .package_xml import CheckPackageCommand
+
+def please_install(module, debian_package_suffix):
+    sys.exit("""Unable to import {module}. Please install it on this system.
+
+        sudo apt-get install python{version}-{suffix}""".format(
+            module=module, version= sys.version_info.major,
+            suffix=debian_package_suffix))
+
 
 def main():
+
+    try:
+        import apt
+    except ImportError:
+        please_install('apt', 'apt')
+    from .apt_tracer import AptTracerCommand
+
+    try:
+        import rosdep2
+    except ImportError:
+        please_install('rosdep2', 'rosdep-modules')
+    from .rosdep import CheckRosdepCommand
+
+    try:
+        import catkin_pkg
+    except ImportError:
+        please_install('catkin_pkg', 'catkin-pkg-modules')
+    from .package_xml import CheckPackageCommand
+
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     entry_points={
         'console_scripts': [
             'py3-ready = py3_ready.cli:main',
-	    ]
+        ]
     },
     author='Shane Loretz',
     author_email='sloretz@openrobotics.org',
@@ -38,5 +38,6 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     license='Apache License 2.0',
+    url='https://github.com/osrf/py3-ready',
     install_requires=[],  # TODO(sloretz) what to do if deps are debian packages?
 )


### PR DESCRIPTION
Resolves #14 . I still need to release to PyPI once this is merged.

This also makes the CLI a little friendlier when dependencies are missing.